### PR TITLE
Add Tom Tag to match current Release Train tagging logic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   addfluxtag:
     description: 'Create a FluxCD friendly tag for the branch and push to repository'
     required: false
+  addtomtag:
+    description: 'Create a TOM format tag for the branch and push to repository'
+    required: false
   dockerfile:
     description: 'Use dockerfile when you would like to explicitly build a Dockerfile'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ function main() {
   fi
   BRANCH=$(echo $BRANCH | sed -e "s/\//-/g")
   isOnMaster=$([ "${BRANCH}" == "master" ] && echo "true" || echo "false")
-  isReleaseBranch=$(! [ "${BRANCH/release\//}" = "${BRANCH}" ] && echo "true" || echo "false")
+  isReleaseBranch=$(! [ "${BRANCH/release-/}" = "${BRANCH}" ] && echo "true" || echo "false")
   isGitTag=$([ "${GITHUB_REF_TYPE}" == "tag" ] && echo "true" || echo "false")
   hasCustomTag=$([ $(echo "${INPUT_NAME}" | sed -e "s/://g") != "${INPUT_NAME}" ] && echo "true" || echo "false")
   # End globals
@@ -155,7 +155,7 @@ function addTomTag() {
     local DATESTAMP=$(TZ=UTC git show --quiet HEAD --date='format-local:%y-%m-%d' --format="%cd")
     local TOM_TAG="${DATESTAMP}.${GITHUB_RUN_NUMBER}"
   elif $isReleaseBranch; then
-    local TOM_TAG="${BRANCH//release\//}-hotfix"
+    local TOM_TAG="${BRANCH/release-/}-hotfix"
   elif $isPullRequest; then
     local TOM_TAG="${PR_NAME}.${GITHUB_RUN_NUMBER}"
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,10 +8,26 @@ function main() {
   sanitize "${INPUT_USERNAME}" "username"
   sanitize "${INPUT_PASSWORD}" "password"
 
+  # Set global booleans and values for use throughout script
   REGISTRY_NO_PROTOCOL=$(echo "${INPUT_REGISTRY}" | sed -e 's/^https:\/\///g')
   if uses "${INPUT_REGISTRY}" && ! isPartOfTheName "${REGISTRY_NO_PROTOCOL}"; then
     INPUT_NAME="${REGISTRY_NO_PROTOCOL}/${INPUT_NAME}"
   fi
+
+  SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+  isPullRequest=$(! [ "${GITHUB_REF/refs\/pull\//}" = "${GITHUB_REF}" ] && echo "true" || echo "false")
+  if $isPullRequest; then
+    BRANCH=$GITHUB_HEAD_REF
+    PR_NAME="PR$(echo $GITHUB_REF_NAME | cut -d '/' -f1)"
+  else
+    BRANCH=$GITHUB_REF_NAME
+  fi
+  BRANCH=$(echo $BRANCH | sed -e "s/\//-/g")
+  isOnMaster=$([ "${BRANCH}" == "master" ] && echo "true" || echo "false")
+  isReleaseBranch=$(! [ "${BRANCH/release\//}" = "${BRANCH}" ] && echo "true" || echo "false")
+  isGitTag=$([ "${GITHUB_REF_TYPE}" == "tag" ] && echo "true" || echo "false")
+  hasCustomTag=$([ $(echo "${INPUT_NAME}" | sed -e "s/://g") != "${INPUT_NAME}" ] && echo "true" || echo "false")
+  # End globals
 
   if uses "${INPUT_TAGS}"; then
     TAGS=$(echo "${INPUT_TAGS}" | sed "s/,/ /g")
@@ -22,21 +38,6 @@ function main() {
   if uses "${INPUT_WORKDIR}"; then
     changeWorkingDirectory
   fi
-
-  # Set up a bunch of Global Data
-  SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
-  isPullRequest=[ $(echo "${GITHUB_REF}" | sed -e "s/refs\/pull\///g") != "${GITHUB_REF}" ]
-  if $isPullRequest; then
-    BRANCH=$GITHUB_HEAD_REF
-    PR_NAME="PR$(echo $GITHUB_REF_NAME | cut -d '/' -f1)"
-  else
-    BRANCH=$GITHUB_REF_NAME
-  fi
-  BRANCH=$(echo $BRANCH | sed -e "s/\//-/g")
-  isOnMaster=[ "${BRANCH}" = "master" ]
-  isReleaseBranch=[[ $BRANCH =~ release.* ]]
-  isGitTag=[ "${GITHUB_REF_TYPE}" == "tag" ]
-  hasCustomTag=[ $(echo "${INPUT_NAME}" | sed -e "s/://g") != "${INPUT_NAME}" ]
 
   echo ${INPUT_PASSWORD} | docker login -u ${INPUT_USERNAME} --password-stdin ${INPUT_REGISTRY}
 
@@ -88,14 +89,14 @@ function isPartOfTheName() {
 }
 
 function translateDockerTag() {
-  if isPullRequest; then
+  if $isPullRequest; then
     TAGS="${GITHUB_SHA}"
-  elif hasCustomTag; then
+  elif $hasCustomTag; then
     TAGS=$(echo ${INPUT_NAME} | cut -d':' -f2)
     INPUT_NAME=$(echo ${INPUT_NAME} | cut -d':' -f1)
-  elif isOnMaster; then
+  elif $isOnMaster; then
     TAGS="latest"
-  elif isGitTag; then
+  elif $isGitTag; then
     if usesBoolean "${INPUT_TAG_NAMES}"; then
       TAGS=$GITHUB_REF_NAME
     else
@@ -150,12 +151,12 @@ function addFluxTag() {
 }
 
 function addTomTag() {
-  if isOnMaster; then
+  if $isOnMaster; then
     local DATESTAMP=$(TZ=UTC git show --quiet HEAD --date='format-local:%y-%m-%d' --format="%cd")
     local TOM_TAG="${DATESTAMP}.${GITHUB_RUN_NUMBER}"
-  elif isReleaseBranch; then
+  elif $isReleaseBranch; then
     local TOM_TAG="${BRANCH//release\//}-hotfix"
-  elif isPullRequest; then
+  elif $isPullRequest; then
     local TOM_TAG="${PR_NAME}.${GITHUB_RUN_NUMBER}"
   else
     local TOM_TAG="${BRANCH}.${SHORT_SHA}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -154,10 +154,10 @@ function addTomTag() {
   if $isOnMaster; then
     local DATESTAMP=$(TZ=UTC git show --quiet HEAD --date='format-local:%y-%m-%d' --format="%cd")
     local TOM_TAG="${DATESTAMP}.${GITHUB_RUN_NUMBER}"
-  elif $isReleaseBranch; then
-    local TOM_TAG="${BRANCH/release-/}-hotfix"
   elif $isPullRequest; then
     local TOM_TAG="${PR_NAME}.${GITHUB_RUN_NUMBER}"
+  elif $isReleaseBranch; then
+    local TOM_TAG="${BRANCH/release-/}-hotfix"
   else
     local TOM_TAG="${BRANCH}.${SHORT_SHA}"
   fi

--- a/test.bats
+++ b/test.bats
@@ -8,6 +8,7 @@ setup(){
   ) > mockReturns
 
   export GITHUB_REF='refs/heads/master'
+  export GITHUB_REF_NAME='master'
   export INPUT_USERNAME='USERNAME'
   export INPUT_PASSWORD='PASSWORD'
   export INPUT_NAME='my/repository'

--- a/test.bats
+++ b/test.bats
@@ -26,6 +26,7 @@ teardown() {
 
 @test "it pushes master branch to latest" {
   export GITHUB_REF='refs/heads/master'
+  export GITHUB_REF_NAME='master'
 
   run /entrypoint.sh
 
@@ -40,6 +41,7 @@ teardown() {
 
 @test "it pushes branch as name of the branch" {
   export GITHUB_REF='refs/heads/myBranch'
+  export GITHUB_REF_NAME='myBranch'
 
   run /entrypoint.sh
 
@@ -51,6 +53,7 @@ teardown() {
 
 @test "it converts dashes in branch to hyphens" {
   export GITHUB_REF='refs/heads/myBranch/withDash'
+  export GITHUB_REF_NAME='myBranch/withDash'
 
   run /entrypoint.sh
 
@@ -62,6 +65,8 @@ teardown() {
 
 @test "it pushes tags to latest" {
   export GITHUB_REF='refs/tags/myRelease'
+  export GITHUB_REF_NAME='myRelease'
+  export GITHUB_REF_TYPE='tag'
 
   run /entrypoint.sh
 
@@ -76,6 +81,8 @@ teardown() {
 
 @test "with tag names it pushes tags using the name" {
   export GITHUB_REF='refs/tags/myRelease'
+  export GITHUB_REF_NAME='myRelease'
+  export GITHUB_REF_TYPE='tag'
   export INPUT_TAG_NAMES="true"
 
   run /entrypoint.sh
@@ -88,6 +95,8 @@ teardown() {
 
 @test "with tag names set to false it doesn't push tags using the name" {
   export GITHUB_REF='refs/tags/myRelease'
+  export GITHUB_REF_NAME='myRelease'
+  export GITHUB_REF_TYPE='tag'
   export INPUT_TAG_NAMES="false"
 
   run /entrypoint.sh
@@ -100,8 +109,10 @@ teardown() {
 
 @test "it pushes specific Dockerfile to latest" {
   export INPUT_DOCKERFILE='MyDockerFileName'
+  export GITHUB_REF='refs/heads/master'
+  export GITHUB_REF_NAME='master'
 
-  run /entrypoint.sh  export GITHUB_REF='refs/heads/master'
+  run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::latest"
 
@@ -315,6 +326,7 @@ teardown() {
 
 @test "it pushes pull requests when configured" {
   export GITHUB_REF='refs/pull/24/merge'
+  export GITHUB_REF_NAME='24/merge'
   export GITHUB_SHA='12169ed809255604e557a82617264e9c373faca7'
   export INPUT_PULL_REQUESTS='true'
 
@@ -472,6 +484,7 @@ teardown() {
 
 @test "it provides a possibility to define multiple tags" {
   export GITHUB_REF='refs/heads/master'
+  export GITHUB_REF_NAME='master'
   export INPUT_TAGS='A,B,C'
 
   run /entrypoint.sh
@@ -487,6 +500,7 @@ teardown() {
 
 @test "it provides a possibility to define one tag" {
   export GITHUB_REF='refs/heads/master'
+  export GITHUB_REF_NAME='master'
   export INPUT_TAGS='A'
 
   run /entrypoint.sh
@@ -500,6 +514,7 @@ teardown() {
 
 @test "it caches the first image when multiple tags defined" {
   export GITHUB_REF='refs/heads/master'
+  export GITHUB_REF_NAME='master'
   export INPUT_TAGS='A,B'
   export INPUT_CACHE='true'
 


### PR DESCRIPTION
The format appears to be company wide, but the exact implementation that I referenced was here: https://github.com/TakeoffTech/osr-emulator/blob/master/.azure/versions.sh

The build number part of the tag will reset compared to what it currently is in Azure.
If the current situation is unmatched, it will default to tagging with SHORT_SHA.