### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ All `buildargs` will be masked, so that they don't appear in the logs.
 
 ```yaml
 - name: Publish to Registry
-  uses: elgohr/Publish-Docker-Github-Action@master
+  uses: elgohr/Publish-Docker-Github-Action@v5
   env:
     MY_FIRST: variableContent
     MY_SECOND: variableContent
@@ -170,7 +170,7 @@ Use `buildoptions` when you want to configure [options](https://docs.docker.com/
 
 ```yaml
 - name: Publish to Registry
-  uses: elgohr/Publish-Docker-Github-Action@master
+  uses: elgohr/Publish-Docker-Github-Action@v5
   with:
     name: myDocker/repository
     username: ${{ secrets.DOCKER_USERNAME }}
@@ -183,7 +183,7 @@ Use `tags` when you want to bring your own tags (separated by comma).
 
 ```yaml
 - name: Publish to Registry
-  uses: elgohr/Publish-Docker-Github-Action@master
+  uses: elgohr/Publish-Docker-Github-Action@v5
   with:
     name: myDocker/repository
     username: ${{ secrets.DOCKER_USERNAME }}
@@ -209,7 +209,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: myDocker/repository
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore